### PR TITLE
support colon in dictionary values

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,14 @@ When defining an object type parameter, create it as a pseudo dictionary as belo
 | command | A command is a namespace, method, parameter combiniation used to control Kodi function (fmt: Namespace.Method) |
 </br>
 
+Parameters can be one of the following types:
+
+- string (default)
+- boolean (true / false)
+- integer
+- list (`[ ... , ... ]`)
+- dict (`{ key: value, ... }`)
+
 ---
 
 ## Usage
@@ -358,3 +366,14 @@ Still TODO:
 - Edit parameters prior to call to avoid runtime error.
 - Provide additional help/runtime detail on parameters
 - Different output formats (rather than just raw and formatted json)
+
+---
+### Stream a URL
+
+```
+SYNTAX:
+    kodi-cli Player.Open item='{file:https://getsamplefiles.com/download/mkv/sample-1.mkv}'
+
+OUTPUT:
+{"id":1,"jsonrpc":"2.0","result":"OK"}
+```

--- a/kodi_common.py
+++ b/kodi_common.py
@@ -38,7 +38,7 @@ def make_dict_from_string(token: str) -> dict:
     entry_list = text.split(",")
     result_dict = {}
     for entry in entry_list:
-        key_val = entry.split(":")
+        key_val = entry.split(":", 1)
         key = key_val[0].strip()
         value = key_val[1].strip()
         if is_integer(value):


### PR DESCRIPTION
I wanted to use kodi-cli to play a URL directly and this requires the value of a nested key/value pair to contain colons.